### PR TITLE
Removing accelerometer and peer-peer device caps

### DIFF
--- a/coco2d-tvos/Info.plist
+++ b/coco2d-tvos/Info.plist
@@ -35,13 +35,13 @@
 	<key>UIRequiredDeviceCapabilities</key>
 	<dict>
 		<key>accelerometer</key>
-		<true/>
+		<false/>
 		<key>gamekit</key>
 		<true/>
 		<key>opengles-1</key>
 		<true/>
 		<key>peer-peer</key>
-		<true/>
+		<false/>
 	</dict>
 	<key>UIStatusBarHidden</key>
 	<true/>


### PR DESCRIPTION
The project wouldn't start on hardware with the acceleromater and peer-peer device capabilities required. This is on XCode Version 7.1 beta 3 (7B85) with the AppleTV running tvOS 9.0 (13T5379f).

[NB: It will run fine on the simulator with these values set to true - just seems to a problem on hardware.]
